### PR TITLE
Add iperf3 TV (network throughput tester)

### DIFF
--- a/packages/DmitryMaksakov__samsung-tv-iperf3.json
+++ b/packages/DmitryMaksakov__samsung-tv-iperf3.json
@@ -1,0 +1,10 @@
+{
+  "name": "iperf3 TV",
+  "description": "Measures your Samsung TV's network throughput to an iperf3 server, upload or download. Requires a small WebSocket-to-TCP relay on your LAN.",
+  "repo": "DmitryMaksakov/samsung-tv-iperf3",
+  "source": "build",
+  "branch": "main",
+  "project_path": "app",
+  "skip_npm": true,
+  "output_name": "iperf3-TV.wgt"
+}


### PR DESCRIPTION
Adds **iperf3 TV** — a Tizen web app that measures the TV's own network throughput against a real `iperf3` server, upload or download.

Repo: https://github.com/DmitryMaksakov/samsung-tv-iperf3

### Manifest

`packages/DmitryMaksakov__samsung-tv-iperf3.json`

```json
{
  "name": "iperf3 TV",
  "description": "Measures your Samsung TV's network throughput to an iperf3 server, upload or download. Requires a small WebSocket-to-TCP relay on your LAN.",
  "repo": "DmitryMaksakov/samsung-tv-iperf3",
  "source": "build",
  "branch": "main",
  "project_path": "app",
  "skip_npm": true,
  "output_name": "iperf3-TV.wgt"
}
```

### Why `source: build`

The Tizen web project is `app/` (`config.xml`, `index.html`, `icon.png`, `css/`, `js/`); the repo root holds only the Node test harnesses and the relay. Hence:

- `project_path: "app"`
- `skip_npm: true` — the root `package.json`'s only dependency (`ws`) serves `tools/` and `relay/`. The app itself is dependency-free ES5-era JS with no build step.

No `pre_build` and no `overlay` needed — the repo ships its own `config.xml`.

### About the app

It speaks the real iperf3 wire protocol from JavaScript. A `.wgt` has no raw TCP sockets, so it needs a small WebSocket→TCP relay alongside the iperf3 server (published multi-arch as `dmitry0xff/iperf3-ws-relay`). **The app does nothing without that relay**, which is why the description says so up front.

The build ships a default target of `192.168.1.1:5202`; address, port, duration, stream count and direction are all editable on the TV with the remote.

### Checks

- [x] Open-source — MIT
- [x] I have the legal right to have this redistributed (I am the author)
- [x] Tested on a real device — Samsung QE65S95B, Tizen 6.5 (should work on any Tizen 4.0+ Samsung TV)
- [x] Virus/malware-free to the best of my knowledge

Validated locally with the same steps CI runs: `check-jsonschema --schemafile packages.schema.json packages/*.json`, the structural check block from `validate-packages.yml` (39 manifests, 40 unique output names), and `scripts/build-manifests.sh` (`build: 9`).
