### PR TITLE
Add tacplayer

### DIFF
--- a/packages/sfsdffesfsfg-cloud__tacplayer.json
+++ b/packages/sfsdffesfsfg-cloud__tacplayer.json
@@ -1,0 +1,8 @@
+{
+  "name": "tacplayer",
+  "description": "Custom Jellyfin Tizen client with cinematic red UI for Samsung TV",
+  "repo": "sfsdffesfsfg-cloud/tacplayer",
+  "source": "release",
+  "branch": "v0.1.0",
+  "output_name": "tacplayer.wgt"
+}


### PR DESCRIPTION
Adds tacplayer (custom Jellyfin Tizen client) from release asset at sfsdffesfsfg-cloud/tacplayer.

Made with [Cursor](https://cursor.com)