### PR TITLE
Add RÚV apps (Sarpur, Barnaefni, Unglingar, Menntun, Útvarp)

### DIFF
--- a/packages/sverrirs__ruv-app-samsung.json
+++ b/packages/sverrirs__ruv-app-samsung.json
@@ -1,6 +1,6 @@
 {
   "name": "RÚV",
-  "description": "Apps from RÚV, the Icelandic national broadcaster: Sarpur on demand, Barnaefni for children, Unglingar for teens, Menntun for education, and Útvarp radio.",
+  "description": "Apps for RÚV, the Icelandic national broadcaster: Sarpur on demand, Barnaefni for children, Unglingar for teens, Menntun for education, and Útvarp radio (not affiliated with RÚV)",
   "repo": "sverrirs/ruv-app-samsung",
   "repo_label": "sverrirs",
   "source": "release",

--- a/packages/sverrirs__ruv-app-samsung.json
+++ b/packages/sverrirs__ruv-app-samsung.json
@@ -2,7 +2,7 @@
   "name": "RÚV",
   "description": "Apps for RÚV, the Icelandic national broadcaster: Sarpur on demand, Barnaefni for children, Unglingar for teens, Menntun for education, and Útvarp radio (not affiliated with RÚV)",
   "repo": "sverrirs/ruv-app-samsung",
-  "repo_label": "sverrirs",
+  "repo_label": "RÚV VOD",
   "source": "release",
   "branch": "master",
   "assets": [

--- a/packages/sverrirs__ruv-app-samsung.json
+++ b/packages/sverrirs__ruv-app-samsung.json
@@ -1,0 +1,15 @@
+{
+  "name": "RÚV",
+  "description": "Apps from RÚV, the Icelandic national broadcaster: Sarpur on demand, Barnaefni for children, Unglingar for teens, Menntun for education, and Útvarp radio.",
+  "repo": "sverrirs/ruv-app-samsung",
+  "repo_label": "sverrirs",
+  "source": "release",
+  "branch": "master",
+  "assets": [
+    { "match": "RUVVod.wgt", "output_name": "RUVVod.wgt" },
+    { "match": "RUVKids.wgt", "output_name": "RUVKids.wgt" },
+    { "match": "RUVUng.wgt", "output_name": "RUVUng.wgt" },
+    { "match": "RUVMennta.wgt", "output_name": "RUVMennta.wgt" },
+    { "match": "RUVUtvarp.wgt", "output_name": "RUVUtvarp.wgt" }
+  ]
+}


### PR DESCRIPTION
Adds five Tizen apps built **for** the public services of **RÚV**, the Icelandic national broadcaster.
These are independently developed and **not affiliated with or endorsed by RÚV**.

| App | Asset | What it is |
|---|---|---|
| Sarpur | `RUVVod.wgt` | The main on-demand catalogue |
| Barnaefni | `RUVKids.wgt` | Children's programming |
| Unglingar | `RUVUng.wgt` | Teen programming |
| Menntun | `RUVMennta.wgt` | Educational programming |
| Útvarp | `RUVUtvarp.wgt` | Radio, live and on demand |

One file added: `packages/sverrirs__ruv-app-samsung.json`. Nothing else touched.

**Details**

- `source: "release"` with the `assets[]` form, because a single release carries all five packages.
- The packages are published **unsigned by design**. A Samsung distributor certificate names the specific
  televisions it may install on by DUID, so a package signed by the publisher could only ever install on
  the publisher's own sets. Users sign with their own certificate, which is exactly what Apps2Samsung
  automates.
- Releases are named CalVer (`YYYY.MM.DD`) and published as non-draft, non-prerelease, so
  `releases/latest` resolves correctly for the sync workflow.
- Every release also carries `SHA256SUMS` and a `manifest.json` listing each app's application id,
  package id, version and digest.
- Validated locally against `packages.schema.json`.

Latest release: https://github.com/sverrirs/ruv-app-samsung/releases/latest

Thanks for maintaining this. The tool made the certificate and permit steps a non-issue for our users.
