### PR TITLE
Add RÚV Live (Sjónvarp), live TV from the Icelandic national broadcaster

### DIFF
--- a/packages/sverrirs__ruv-live-samsung.json
+++ b/packages/sverrirs__ruv-live-samsung.json
@@ -1,0 +1,11 @@
+{
+  "name": "RÚV Live",
+  "description": "Live TV from RÚV, the Icelandic national broadcaster: the RÚV and RÚV 2 channels, with the running schedule and rewind inside the live window (not affiliated with RÚV)",
+  "repo": "sverrirs/ruv-live-samsung",
+  "repo_label": "RÚV Live",
+  "source": "release",
+  "branch": "master",
+  "assets": [
+    { "match": "RUVLive.wgt", "output_name": "RUVLive.wgt" }
+  ]
+}


### PR DESCRIPTION
Adds the live TV companion to the RÚV on-demand apps in #22. Built **for** the public services of
**RÚV**, the Icelandic national broadcaster, independently developed and **not affiliated with or
endorsed by RÚV**.

| App | Asset | What it is |
|---|---|---|
| Sjónvarp | `RUVLive.wgt` | RÚV and RÚV 2 live, with the running schedule and rewind inside the live window |

One file added: `packages/sverrirs__ruv-live-samsung.json`. Nothing else touched.

**Details**

- `source: "release"` with the `assets[]` form, **deliberately, even though this release carries a single
  `.wgt`**. The legacy `output_name` path takes the first asset URL in the release with no name filter
  (`jq '(.assets // [])[] | .browser_download_url' | head -n 1`), and this release also ships
  `SHA256SUMS` and `manifest.json`, which the API happens to order ahead of the package. An exact
  `match` pins it to `RUVLive.wgt`.
- Separate repository from #22 rather than a sixth asset there, because this is a separate app with its
  own version line and its own Tizen package id (`cFFG22dMoM`, vs `FDg1NvGl3W` and friends for the VOD
  apps).
- The package is published **unsigned by design**. A Samsung distributor certificate names the specific
  televisions it may install on by DUID, so a package signed by the publisher could only ever install on
  the publisher's own sets. Users sign with their own certificate, which is exactly what Apps2Samsung
  automates.
- Releases are named CalVer (`YYYY.MM.DD`) and published as non-draft, non-prerelease, so
  `releases/latest` resolves correctly for the sync workflow.
- Every release also carries `SHA256SUMS` and a `manifest.json` listing the application id, package id,
  version, size and digest.
- Validated locally: `check-jsonschema --schemafile packages.schema.json packages/*.json` passes, and the
  structural check reports 42 manifests with 43 unique output names.

Latest release: https://github.com/sverrirs/ruv-live-samsung/releases/latest

Thanks again for maintaining this.
