### PR TITLE
TVapp (Fixed): fetch from GitHub Releases instead of the committed wgt

### DIFF
--- a/packages/PatrickSt1991__TVapp.json
+++ b/packages/PatrickSt1991__TVapp.json
@@ -1,9 +1,11 @@
 {
   "name": "TVapp (Fixed)",
-  "description": "TVapp with community fixes: channel switching now works (was stuck on stream #1), a readable exit dialog, and a compact channel banner. Pending upstream KaashDev/TVapp#4.",
+  "description": "TVapp with community fixes: channel switching now works (was stuck on stream #1), a readable exit dialog, a compact channel banner and larger on-screen text. Pending upstream KaashDev/TVapp#4.",
   "repo": "PatrickSt1991/TVapp",
   "repo_label": "PatrickSt1991 (fork)",
-  "source": "direct",
-  "url": "https://raw.githubusercontent.com/PatrickSt1991/TVapp/main/TVapp.wgt",
-  "output_name": "TVApp-Fixed.wgt"
+  "source": "release",
+  "branch": "main",
+  "assets": [
+    { "match": "TVapp.wgt", "output_name": "TVApp-Fixed.wgt" }
+  ]
 }


### PR DESCRIPTION
Follow-up to PatrickSt1991/TVapp#3.

`PatrickSt1991/TVapp` now builds and signs its widget in CI and publishes it as a release asset, so this entry no longer needs to point at the hand-built `TVapp.wgt` in the repo root — that committed binary is exactly what kept drifting out of sync with the sources (its signature still matched a September 2024 build while `js/main.js` had moved on).

```diff
-  "source": "direct",
-  "url": "https://raw.githubusercontent.com/PatrickSt1991/TVapp/main/TVapp.wgt",
-  "output_name": "TVApp-Fixed.wgt"
+  "source": "release",
+  "branch": "main",
+  "assets": [
+    { "match": "TVapp.wgt", "output_name": "TVApp-Fixed.wgt" }
+  ]
```

**Why `assets[]` and not a bare `output_name`:** the legacy single-`output_name` path in `sync-packages.yml` takes the *first* asset on the release, whatever it is. The TVapp CI always emits exactly one asset named `TVapp.wgt`, so an exact match costs one line and fails loudly if that ever changes, instead of silently pulling the wrong file.

`branch: "main"` because that is where the releases are cut (the sync itself resolves via `/releases/latest`).

Also refreshed the description to mention the larger on-screen text — the README table is regenerated from the manifests by the sync workflow, so no hand edit there.

## Checks run locally
- `packages.schema.json` validation over all `packages/*.json` — valid (the `release` branch of the `allOf` requires `branch` and exactly one of `output_name`/`assets`, and forbids `url`)
- the structural checks from `validate-packages.yml` — filename matches the repo slug, one manifest per repo, `TVApp-Fixed.wgt` still unique across the bundle

No change needed to `.github/state/last_seen.json`: the sync rebuilds it from scratch each run, so the now-orphaned `direct:PatrickSt1991/TVapp` key drops out by itself and a `release:PatrickSt1991/TVapp` key appears — which also means the next sync sees a change and rebuilds the bundle.

Current release picked up by this: [`v1.0.1-20260821-2026`](https://github.com/PatrickSt1991/TVapp/releases/tag/v1.0.1-20260821-2026).