### PR TITLE
feat: add EN TV Player

### DIFF
--- a/packages/Nur-allhi__en-tvplayer.json
+++ b/packages/Nur-allhi__en-tvplayer.json
@@ -1,0 +1,8 @@
+{
+  "name": "EN TV Player",
+  "description": "IPTV player for Samsung Tizen TVs with full remote control, DRM support, and per-channel proxy.",
+  "repo": "Nur-allhi/en-tvplayer",
+  "source": "release",
+  "branch": "main",
+  "output_name": "EN-IPTV_Player.wgt"
+}


### PR DESCRIPTION
## EN TV Player

**IPTV player for Samsung Tizen TVs with full remote control, DRM support, and per-channel proxy.**

### What is it?

A free, open-source IPTV player built specifically for Samsung Tizen Smart TVs. No ads, no subscriptions, no cloud — just your playlists, your network, your TV.

### Features

- 🎮 **Full Remote Control** — Every button on Samsung remote works (number pad, color keys, media controls)
- 📺 **All Streaming Formats** — HLS, DASH, MSS via Shaka Player
- 🔐 **DRM Support** — ClearKey and PlayReady for protected content
- 🗂️ **Big Playlist Ready** — Virtualized list handles 5,000+ channels
- 🔒 **Per-Channel Proxy** — Toggle CORS proxy for each channel individually
- ⚡ **Fast Setup** — Install WGT → paste playlist URL → watch

### Source

- **Repository:** [Nur-allhi/en-tvplayer](https://github.com/Nur-allhi/en-tvplayer)
- **License:** MIT
- **Tested on:** Samsung Tizen 5.0+

### Release

- **Version:** v1.1.0
- **WGT:** [EN-IPTV_Player_v1.1.0.zip](https://github.com/Nur-allhi/en-tvplayer/releases/tag/v1.1.0)

---

First community release — feedback welcome!