### PR TITLE
sync: unwrap release assets that ship the .wgt inside a .zip

### DIFF
--- a/.github/workflows/sync-packages.yml
+++ b/.github/workflows/sync-packages.yml
@@ -332,7 +332,7 @@ jobs:
       - name: Install jq & curl
         run: |
           sudo apt-get update
-          sudo apt-get install -y jq curl git
+          sudo apt-get install -y jq curl git unzip
 
       - name: Compile manifests
         run: bash scripts/build-manifests.sh
@@ -401,6 +401,7 @@ jobs:
               for idx in $(seq 0 $((n_assets - 1))); do
                 match=$(jq -r ".releases[\"$repo\"].assets[$idx].match" "$CFG")
                 outname=$(jq -r ".releases[\"$repo\"].assets[$idx].output_name // \"\"" "$CFG")
+                extract=$(jq -r ".releases[\"$repo\"].assets[$idx].extract // \"\"" "$CFG")
                 url=$(echo "$json" | jq -r --arg m "$match" \
                   '(.assets // [])[] | select(.name == $m) | .browser_download_url' 2>/dev/null | head -n 1)
                 if [ -z "$url" ]; then
@@ -419,10 +420,12 @@ jobs:
                 fi
                 echo "Downloading $url -> external_wgts/$outname"
                 curl -L -o "external_wgts/$outname" "$url"
+                bash scripts/unwrap-zip.sh "external_wgts/$outname" "$extract"
               done
             else
               # Legacy style — first non-empty URL across all assets (matches old behavior).
               outname=$(jq -r ".releases[\"$repo\"].output_name" "$CFG")
+              extract=$(jq -r ".releases[\"$repo\"].extract // \"\"" "$CFG")
               url=$(echo "$json" | jq -r '(.assets // [])[] | .browser_download_url // empty' 2>/dev/null | head -n 1)
               if [ -z "$url" ]; then
                 echo "::warning title=Package skipped::No release asset found for $repo (latest or prerelease) — skipping this package."
@@ -434,6 +437,7 @@ jobs:
               fi
               echo "Downloading $url -> external_wgts/$outname"
               curl -L -o "external_wgts/$outname" "$url"
+              bash scripts/unwrap-zip.sh "external_wgts/$outname" "$extract"
             fi
           done
 
@@ -445,13 +449,14 @@ jobs:
         if: ${{ steps.config.outputs.config != '' }}
         run: |
           CFG="${{ steps.config.outputs.config }}"
-          jq -r '.direct | to_entries[] | "\(.key) \(.value.url // .value) \(.value.output_name // "")"' "$CFG" |
-          while read repo url outname; do
+          jq -r '.direct | to_entries[] | "\(.key) \(.value.url // .value) \(.value.output_name // "") \(.value.extract // "")"' "$CFG" |
+          while read -r repo url outname extract; do
             [ -n "$repo" ] || continue
             if [ -z "$outname" ] || [ "$outname" = "null" ]; then
               outname="${repo##*/}.wgt"
             fi
             curl -L -o "external_wgts/$outname" "$url"
+            bash scripts/unwrap-zip.sh "external_wgts/$outname" "$extract"
           done
 
       - uses: actions/upload-artifact@v4
@@ -479,6 +484,21 @@ jobs:
           cp built/**/*.wgt final_wgts/ 2>/dev/null || true
           cp external/*.wgt final_wgts/ 2>/dev/null || true
           cp external/*.tpk final_wgts/ 2>/dev/null || true
+
+          # A .wgt is itself a zip, so a zip *wrapping* a .wgt copies in here
+          # unnoticed and ships an uninstallable file. Drop those rather than
+          # exiting, so one bad upstream cannot sink the whole bundle.
+          command -v unzip >/dev/null || sudo apt-get install -y unzip
+          for f in final_wgts/*.wgt final_wgts/*.tpk; do
+            [ -e "$f" ] || continue
+            if unzip -Z1 "$f" 2>/dev/null | grep -qiE '\.(wgt|tpk)$'; then
+              echo "::warning title=Nested archive::$(basename "$f") contains a .wgt/.tpk — it is a zip wrapper, not a package. Set \"extract\" in its manifest. Dropping it from this bundle."
+              rm -f "$f"
+            elif ! unzip -Z1 "$f" 2>/dev/null | grep -qx 'config.xml'; then
+              echo "::warning title=No config.xml::$(basename "$f") has no config.xml at its root — it may not be a valid package."
+            fi
+          done
+
           echo "Final WGT files:"
           ls -l final_wgts
 

--- a/packages.schema.json
+++ b/packages.schema.json
@@ -26,6 +26,7 @@
     "overlay": { "type": "string", "pattern": "^[A-Za-z0-9._-]+$", "description": "build only. Name of a directory under apps/ whose contents are copied over the project before packaging (e.g. a config.xml the upstream doesn't ship)." },
     "url": { "type": "string", "pattern": "^https?://", "description": "direct only. Absolute URL to the .wgt." },
     "output_name": { "type": "string", "pattern": "\\.(wgt|tpk)$", "description": "Filename inside the bundle. Required unless using assets[]." },
+    "extract": { "type": "string", "minLength": 1, "description": "release/direct only. The downloaded asset is a zip wrapper; extract the entry matching this exact name or regex and use that as the package. Use when upstream ships the .wgt inside a .zip." },
     "assets": {
       "type": "array",
       "minItems": 1,
@@ -36,7 +37,8 @@
         "required": ["match", "output_name"],
         "properties": {
           "match": { "type": "string", "minLength": 1, "description": "Exact asset name or a regex matched against release asset names." },
-          "output_name": { "type": "string", "pattern": "\\.(wgt|tpk)$" }
+          "output_name": { "type": "string", "pattern": "\\.(wgt|tpk)$" },
+          "extract": { "type": "string", "minLength": 1, "description": "This asset is a zip wrapper; extract the entry matching this exact name or regex." }
         }
       }
     }
@@ -46,7 +48,7 @@
       "if": { "required": ["source"], "properties": { "source": { "const": "build" } } },
       "then": {
         "required": ["branch", "output_name"],
-        "not": { "anyOf": [ { "required": ["url"] }, { "required": ["assets"] } ] }
+        "not": { "anyOf": [ { "required": ["url"] }, { "required": ["assets"] }, { "required": ["extract"] } ] }
       }
     },
     {
@@ -56,7 +58,7 @@
         "not": { "anyOf": [ { "required": ["url"] }, { "required": ["skip_npm"] }, { "required": ["pre_build"] }, { "required": ["project_path"] }, { "required": ["overlay"] } ] },
         "oneOf": [
           { "required": ["output_name"], "not": { "required": ["assets"] } },
-          { "required": ["assets"], "not": { "required": ["output_name"] } }
+          { "required": ["assets"], "not": { "anyOf": [ { "required": ["output_name"] }, { "required": ["extract"] } ] } }
         ]
       }
     },

--- a/packages/README.md
+++ b/packages/README.md
@@ -40,6 +40,7 @@ Examples: `PatrickSt1991/flixor-tizen` → `packages/PatrickSt1991__flixor-tizen
 |-------|------|-------|
 | `repo_label` | string | Link text for the README's Repository column. Defaults to the repo owner. |
 | `output_name` | string | Filename inside the bundle. Must end in `.wgt` or `.tpk`. Required for every type **except** a `release` that uses `assets[]`. |
+| `extract` | string | Only when upstream ships the package **inside a `.zip`**. Entry name or regex to pull out of the archive — see [Zip-wrapped downloads](#-zip-wrapped-downloads). |
 
 ### Which fields go with which `source`
 
@@ -48,13 +49,15 @@ Examples: `PatrickSt1991/flixor-tizen` → `packages/PatrickSt1991__flixor-tizen
 | `branch` | ✅ required | ✅ required | ❌ |
 | `output_name` | ✅ *(or `assets`)* | ✅ required | ✅ required |
 | `assets[]` | ✅ *(or `output_name`)* | ❌ | ❌ |
+| `extract` | ⬜ optional | ❌ | ⬜ optional |
 | `url` | ❌ | ❌ | ✅ required |
 | `project_path` | ❌ | ⬜ optional | ❌ |
 | `skip_npm` | ❌ | ⬜ optional | ❌ |
 | `pre_build` | ❌ | ⬜ optional | ❌ |
 | `overlay` | ❌ | ⬜ optional | ❌ |
 
-For a `release`, `output_name` and `assets[]` are **mutually exclusive** — use exactly one.
+For a `release`, `output_name` and `assets[]` are **mutually exclusive** — use exactly one. With
+`assets[]`, put `extract` on the individual asset entry rather than at the top level.
 
 ---
 
@@ -112,6 +115,42 @@ name) and the `output_name` to save it as:
   ]
 }
 ```
+
+---
+
+## 🗜️ Zip-wrapped downloads
+
+Some upstreams publish their `.wgt` **inside a `.zip`** instead of as a bare release asset. Without
+`extract` the sync would download that zip and simply rename it to `output_name`, producing a
+zip-of-a-`.wgt` that installs on nothing — and it fails *silently*, because a `.wgt` is itself a zip,
+so no glob or copy downstream notices.
+
+Set `extract` to the entry name (or a regex) to pull out of the archive:
+
+```json
+{
+  "name": "EN TV Player",
+  "description": "IPTV player for Samsung Tizen TVs with full remote control, DRM support, and per-channel proxy.",
+  "repo": "Nur-allhi/en-tvplayer",
+  "source": "release",
+  "branch": "main",
+  "extract": "[.]wgt$",
+  "output_name": "EN-IPTV_Player.wgt"
+}
+```
+
+The download is replaced in place by the extracted entry, then kept under `output_name`. With
+`assets[]`, `extract` goes on the entry whose asset is the zip:
+
+```json
+"assets": [
+  { "match": "MyApp-.*[.]zip$", "extract": "[.]wgt$", "output_name": "MyApp.wgt" }
+]
+```
+
+If nothing in the archive matches, the sync warns and leaves the download untouched rather than
+failing the run. As a backstop, the publish job inspects every file in the final bundle and drops
+any `.wgt`/`.tpk` that turns out to contain another `.wgt`/`.tpk`.
 
 ---
 

--- a/scripts/build-manifests.sh
+++ b/scripts/build-manifests.sh
@@ -37,13 +37,19 @@ jq -s '
       map(select(.source == "release"))
       | map({
           key: .repo,
-          value: ({ branch } + (if has("assets") then { assets } else { output_name } end))
+          value: ({ branch }
+                   + (if has("assets")  then { assets }  else { output_name } end)
+                   + (if has("extract") then { extract } else {} end))
         })
       | from_entries
     ),
     direct: (
       map(select(.source == "direct"))
-      | map({ key: .repo, value: { url, output_name } })
+      | map({
+          key: .repo,
+          value: ({ url, output_name }
+                   + (if has("extract") then { extract } else {} end))
+        })
       | from_entries
     )
   }

--- a/scripts/unwrap-zip.sh
+++ b/scripts/unwrap-zip.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Unwrap a zip that contains the real package.
+#
+# Some upstreams publish their .wgt inside a .zip release asset. Downloading
+# that asset and renaming it to *.wgt produces a zip-of-a-wgt, which installs
+# on nothing — and fails silently, because a .wgt is itself a zip so no glob or
+# copy downstream notices. Packages in that situation set "extract" in their
+# manifest and the sync workflow calls this script after the download.
+#
+# Usage: unwrap-zip.sh <file> <pattern>
+#   file    - the downloaded file, replaced in place by the extracted entry
+#   pattern - exact entry name or regex; empty/"null" makes this a no-op
+#
+# Never fails the caller: a wrapper that turns out not to match only warns, so
+# one bad upstream cannot break the whole catalog sync.
+set -euo pipefail
+
+file="${1:?usage: unwrap-zip.sh <file> <pattern>}"
+pattern="${2:-}"
+
+[ -n "$pattern" ] && [ "$pattern" != "null" ] || exit 0
+
+if [ ! -s "$file" ]; then
+  echo "::warning title=Extract skipped::$(basename "$file") is missing or empty."
+  exit 0
+fi
+
+inner=$(unzip -Z1 "$file" 2>/dev/null | grep -E "$pattern" | head -n 1 || true)
+if [ -z "$inner" ]; then
+  echo "::warning title=Extract failed::No entry matching '$pattern' inside $(basename "$file") — leaving the download as-is."
+  echo "  Archive contents:"
+  unzip -Z1 "$file" 2>/dev/null | sed 's/^/    /' || echo "    (not a zip archive)"
+  exit 0
+fi
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+unzip -q -j "$file" "$inner" -d "$tmp"
+mv "$tmp/$(basename "$inner")" "$file"
+echo "  Extracted '$inner' from the zip wrapper -> $(basename "$file")"


### PR DESCRIPTION
## The problem

Some upstreams publish their widget **inside a `.zip`** instead of as a bare release asset. The sync downloaded that asset and renamed it to the manifest's `output_name`:

```bash
url=$(echo "$json" | jq -r '(.assets // [])[] | .browser_download_url // empty' | head -n 1)
curl -L -o "external_wgts/$outname" "$url"
```

The result is a zip-of-a-`.wgt`, which installs on nothing — and it fails **silently**, because a `.wgt` is itself a zip, so neither the `cp external/*.wgt` glob in the merge step nor the release upload notices. It ships in the bundle looking perfectly normal.

Spotted while reviewing #29 (that upstream has since re-published v1.1.0 with a bare `.wgt`, so #29 needs no change — but nothing would have told us if it hadn't).

## The fix

**New optional `extract` field** — the entry name, or a regex, to pull out of the downloaded archive:

```json
{
  "repo": "owner/app",
  "source": "release",
  "branch": "main",
  "extract": "[.]wgt$",
  "output_name": "App.wgt"
}
```

Allowed at the top level for `release`/`direct` and per-entry inside `assets[]`. Rejected for `source: "build"`, and rejected at the top level alongside `assets[]`, where it would be silently ignored.

**`scripts/unwrap-zip.sh`** does the unwrapping in place, after every download (all three paths: `assets[]`, legacy `output_name`, and `direct`). It never fails the caller — a pattern matching nothing warns and leaves the file untouched — so one bad upstream can't break the whole catalog sync, matching the behaviour introduced in #18.

**A backstop independent of any manifest**: the publish job now inspects every file in `final_wgts/` and drops any `.wgt`/`.tpk` that turns out to contain another `.wgt`/`.tpk`, warning on ones with no root `config.xml`. This catches an upstream that starts wrapping its asset without anyone updating the manifest.

## Verification

- All 23 `run` blocks pass `bash -n`; workflow parses as YAML.
- `build-manifests.sh` compiles all 49 manifests; every existing entry's shape is byte-identical.
- Schema validated with ajv (2020-12): all 49 current packages still valid, plus targeted cases — `release`+`extract` valid, `assets[].extract` valid, top-level `extract` alongside `assets[]` invalid, `build`+`extract` invalid, `direct`+`extract` valid, `extract: ""` invalid, unknown field still invalid.
- `unwrap-zip.sh` run against a real zip-wrapped release asset (300,923-byte zip containing a 310,201-byte `.wgt`): extracted correctly. Also covered empty/`null` pattern (no-op), non-matching pattern, non-zip input, missing file, a nested `dist/Inner.wgt` entry (flattened), and an already-bare `.wgt` with `extract` set (left untouched).
- Publish-step guard run on a synthetic bundle: dropped a zip wrapper and a nested `.tpk`, kept the real widget, warned on a `config.xml`-less one.

No behaviour change for any package that doesn't set `extract`.