### PR TITLE
Add EN TV Player v1.4.0

### DIFF
--- a/packages/Nur-allhi__en-tvplayer.json
+++ b/packages/Nur-allhi__en-tvplayer.json
@@ -1,10 +1,10 @@
 {
   "name": "EN TV Player",
-  "description": "IPTV player for Samsung Tizen TVs with DRM support, M3U/M3U8 playlists, and per-channel proxy.",
+  "description": "Samsung Tizen TV IPTV Player — plays DRM channels (ClearKey, PlayReady) that other players can't on Tizen.",
   "repo": "Nur-allhi/en-tvplayer",
   "source": "release",
   "branch": "main",
   "assets": [
-    { "match": "EN-IPTV_Player_stable_.*[.]wgt$", "output_name": "EN-IPTV_Player.wgt" }
+    { "match": "\\.wgt$", "output_name": "EN-IPTV_Player.wgt" }
   ]
 }


### PR DESCRIPTION
Add `packages/Nur-allhi__en-tvplayer.json` for EN TV Player v1.4.0.

**Changes:**
- New community package config for [EN TV Player](https://github.com/Nur-allhi/en-tvplayer)
- Plays DRM channels (ClearKey, PlayReady) on Samsung Tizen TVs
- Latest release: [v1.4.0](https://github.com/Nur-allhi/en-tvplayer/releases/tag/v1.4.0) — channel name marquee scroll, sidebar fixes