### PR TITLE
feat: optional "enabled" flag to retire a package without deleting it

### DIFF
--- a/.github/workflows/sync-packages.yml
+++ b/.github/workflows/sync-packages.yml
@@ -555,6 +555,8 @@ jobs:
           # Regenerate the entire Current Packages table from packages/*.json.
           # Rows (name / description / repo link) come from the manifests;
           # the ⚙️ Version column comes from .github/state/last_seen.json.
+          # Manifests with "enabled": false are retired — the sync no longer
+          # ships them, so they are left out of the table and the badge count.
           # Everything outside the table is left untouched.
           import json, glob, re, pathlib
 
@@ -583,6 +585,8 @@ jobs:
               items = []
               for path in glob.glob("packages/*.json"):
                   d = json.loads(pathlib.Path(path).read_text())
+                  if not d.get("enabled", True):
+                      continue
                   repo = d["repo"]
                   label = d.get("repo_label", repo.split("/")[0])
                   items.append((
@@ -610,11 +614,12 @@ jobs:
                   out.append(line)
                   i += 1
               text = "\n".join(out) + "\n"
-              # keep the package-count badge in sync
-              count = len(glob.glob("packages/*.json"))
+              # keep the package-count badge in sync (enabled packages only)
+              count = sum(1 for p in glob.glob("packages/*.json")
+                          if json.loads(pathlib.Path(p).read_text()).get("enabled", True))
               text = re.sub(r"(img\.shields\.io/badge/packages-)\d+(-)", rf"\g<1>{count}\g<2>", text)
               README.write_text(text)
-              print(f"Rendered README table + badge ({count} packages).")
+              print(f"Rendered README table + badge ({count} enabled packages).")
 
           main()
           PY

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🌐 Tizen Community Packages
 [![Sync Tizen Community Packages](https://github.com/Apps2Samsung/tizen-community-packages/actions/workflows/sync-packages.yml/badge.svg)](https://github.com/Apps2Samsung/tizen-community-packages/actions/workflows/sync-packages.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Packages](https://img.shields.io/badge/packages-49-blue.svg)](#-current-packages)
+[![Packages](https://img.shields.io/badge/packages-48-blue.svg)](#-current-packages)
 [![Contributions Welcome](https://img.shields.io/badge/Contributions-Welcome-green.svg)](../../issues)
 [![Tizen](https://img.shields.io/badge/Platform-Tizen-lightgrey.svg)](https://www.tizen.org/)
 [![Community](https://img.shields.io/badge/Community-Driven-orange.svg)](#)
@@ -82,7 +82,6 @@ Please check the [Releases](../../releases) page for version-specific details.
 | **TizenYouTube** | YouTube client for Samsung Tizen TVs. | [sunnyden](https://github.com/sunnyden/TizenYoutube) | `79bfe9e` |
 | **TransportTycoonDeluxe** | OpenTTD is an open source simulation game based upon Transport Tycoon Deluxe. | [dos-ise](https://github.com/dos-ise/openttd-tizen) | `Release` |
 | **TVapp** | Enable seamless playback of HLS/m3u8 streams as channels. | [KaashDev](https://github.com/KaashDev/TVapp) | `latest` |
-| **TVapp (Fixed)** | TVapp with community fixes: channel switching now works (was stuck on stream #1), a readable exit dialog, a compact channel banner and larger on-screen text. Pending upstream KaashDev/TVapp#4. | [PatrickSt1991 (fork)](https://github.com/PatrickSt1991/TVapp) | `v1.0.1-20260826-0421` |
 | **TVideoPlayer** | Tizen TV HTML video player based on videojs. | [TizenTVWebApp](https://github.com/TizenTVWebApp/TVideoPlayer) | `latest` |
 | **Twitch** | Twitch client for Samsung Smart TVs 2015 and newer models. | [fgl27](https://github.com/fgl27/smarttv-twitch) | `ca31512` |
 | **Velvet TV** | Big-screen TV client for the Velvet self-hosted music server. | [aroundmyroom](https://github.com/aroundmyroom/Velvet) | `dc32502` |

--- a/packages.schema.json
+++ b/packages.schema.json
@@ -15,6 +15,7 @@
       "description": "GitHub owner/repo. Used as the manifest key, the README link, and (for build/release) the API target."
     },
     "repo_label": { "type": "string", "minLength": 1, "pattern": "^[^|\n]+$", "description": "Optional link text for the README Repository column. Defaults to the repo owner." },
+    "enabled": { "type": "boolean", "default": true, "description": "Set to false to retire the package without deleting this file: it is skipped by the sync (not built, downloaded, or shipped in the release) and left out of the README table. Absent means true." },
     "source": {
       "enum": ["build", "release", "direct"],
       "description": "build = compiled from source with Tizen Studio; release = prebuilt .wgt from GitHub Releases; direct = downloaded from a fixed URL."

--- a/packages/PatrickSt1991__TVapp.json
+++ b/packages/PatrickSt1991__TVapp.json
@@ -3,6 +3,7 @@
   "description": "TVapp with community fixes: channel switching now works (was stuck on stream #1), a readable exit dialog, a compact channel banner and larger on-screen text. Pending upstream KaashDev/TVapp#4.",
   "repo": "PatrickSt1991/TVapp",
   "repo_label": "PatrickSt1991 (fork)",
+  "enabled": false,
   "source": "release",
   "branch": "main",
   "assets": [

--- a/packages/README.md
+++ b/packages/README.md
@@ -41,6 +41,7 @@ Examples: `PatrickSt1991/flixor-tizen` → `packages/PatrickSt1991__flixor-tizen
 | `repo_label` | string | Link text for the README's Repository column. Defaults to the repo owner. |
 | `output_name` | string | Filename inside the bundle. Must end in `.wgt` or `.tpk`. Required for every type **except** a `release` that uses `assets[]`. |
 | `extract` | string | Only when upstream ships the package **inside a `.zip`**. Entry name or regex to pull out of the archive — see [Zip-wrapped downloads](#-zip-wrapped-downloads). |
+| `enabled` | boolean | `false` retires the package without deleting the file — see [Retiring a package](#-retiring-a-package). Defaults to `true`. |
 
 ### Which fields go with which `source`
 
@@ -230,6 +231,33 @@ Use when the `.wgt`/`.tpk` is hosted at a stable absolute URL (including one com
   "output_name": "Stremio-Tizen4.wgt"
 }
 ```
+
+---
+
+## 🚫 Retiring a package
+
+To stop shipping an app without deleting its manifest — upstream went away, the fix was merged
+upstream, the fork is superseded — set `enabled` to `false`:
+
+```json
+{
+  "name": "TVapp (Fixed)",
+  "description": "TVapp with community fixes.",
+  "repo": "PatrickSt1991/TVapp",
+  "enabled": false,
+  "source": "release",
+  "branch": "main",
+  "assets": [
+    { "match": "TVapp.wgt", "output_name": "TVApp-Fixed.wgt" }
+  ]
+}
+```
+
+`build-manifests.sh` drops disabled manifests before compiling `repos-build.json` /
+`repos-sync.json`, and every downstream job reads only those two files. So the package is no longer
+checked for upstream changes, built, downloaded or attached to the release, and its row disappears
+from the README table and the package-count badge. The file itself stays valid and fully
+schema-checked, so removing the line is all it takes to bring the app back.
 
 ---
 

--- a/scripts/build-manifests.sh
+++ b/scripts/build-manifests.sh
@@ -4,6 +4,11 @@
 # packages/ is the source of truth (one file per app). This script compiles
 # those files back into the two aggregate manifests the sync workflow already
 # consumes, so nothing downstream had to change. Run from the repo root.
+#
+# Manifests with "enabled": false are dropped here. That single filter retires a
+# package everywhere downstream — change detection, the build matrix, the release
+# downloads and the published bundle all read only these compiled manifests — so
+# the file can stay in packages/ without shipping.
 set -euo pipefail
 
 PKG_DIR="${1:-packages}"
@@ -17,7 +22,8 @@ fi
 
 # --- repos-build.json : { "<repo>": { branch, project_path, output_name, [skip_npm], [pre_build] } }
 jq -s '
-  map(select(.source == "build"))
+  map(select(.enabled != false))
+  | map(select(.source == "build"))
   | map({
       key: .repo,
       value: (
@@ -32,7 +38,8 @@ jq -s '
 
 # --- repos-sync.json : { releases: {...}, direct: {...} }
 jq -s '
-  {
+  map(select(.enabled != false))
+  | {
     releases: (
       map(select(.source == "release"))
       | map({
@@ -55,7 +62,10 @@ jq -s '
   }
 ' "${files[@]}" > repos-sync.json
 
-echo "Compiled ${#files[@]} manifest(s):"
+disabled=$(jq -s '[.[] | select(.enabled == false) | .repo] | join(", ")' -r "${files[@]}")
+[ -n "$disabled" ] && echo "Skipped (enabled: false): $disabled"
+
+echo "Read ${#files[@]} manifest(s), compiled:"
 echo "  build:   $(jq 'length' repos-build.json)"
 echo "  release: $(jq '.releases | length' repos-sync.json)"
 echo "  direct:  $(jq '.direct  | length' repos-sync.json)"


### PR DESCRIPTION
Adds an optional `enabled` boolean to the package manifest schema. Setting it to `false` retires a package — it keeps its file in `packages/`, but is no longer built, downloaded, shipped in the release, or listed in the README.

Applied to `PatrickSt1991/TVapp`, which should no longer ship in the bundle.

## How it works

Every downstream job — change detection, the build matrix, the release/direct downloads, the published bundle — reads only `repos-build.json` / `repos-sync.json`, which `scripts/build-manifests.sh` compiles from `packages/*.json`. So a single filter in that script retires a package everywhere; no workflow logic needed a change.

| File | Change |
|---|---|
| `packages.schema.json` | new optional `enabled` boolean (needed — the schema is `additionalProperties: false`) |
| `scripts/build-manifests.sh` | drops disabled manifests from both compiled files; logs `Skipped (enabled: false): …` |
| `.github/workflows/sync-packages.yml` | README renderer skips disabled rows and leaves them out of the package-count badge |
| `packages/PatrickSt1991__TVapp.json` | `"enabled": false` |
| `README.md` | TVapp (Fixed) row removed, badge 49 → 48 |
| `packages/README.md` | field-table entry + a "Retiring a package" section |

Absent means `true`, so all 48 other manifests are untouched. Removing the one line brings an app back.

## Verified locally

- Manifests compile: 48 entries, `PatrickSt1991/TVapp` absent from both files, the unrelated `KaashDev/TVapp` (a `direct` package) still present.
- All 49 manifests validate against the updated schema; `enabled: true`/`false` accepted, a non-boolean rejected.
- The workflow's README renderer, run against the real tree, produces exactly the two intended line changes — no table churn.
- The new `[ -n "$disabled" ] && echo` doesn't trip `set -e` when nothing is disabled.

## Notes

- The stale `release:PatrickSt1991/TVapp` key in `.github/state/last_seen.json` cleans itself up on the next successful sync, which rewrites the whole state file from the compiled manifests.
- `validate-packages.yml` is deliberately unchanged: a disabled package still reserves its `output_name` and is still schema-checked, so re-enabling it can't surprise you with a name collision.