### PR TITLE
docs: spell out which app requests can't be accepted

### DIFF
--- a/.github/ISSUE_TEMPLATE/request-app.yml
+++ b/.github/ISSUE_TEMPLATE/request-app.yml
@@ -9,6 +9,20 @@ body:
         Suggesting an app you didn't build yourself? You're in the right place.
         If you *have* packaged it, use the **Contribute an App** form (or open a pull request) instead.
 
+  - type: markdown
+    attributes:
+      value: |
+        > ⚠️ **Please check this list first — these can't be added:**
+        >
+        > - **Commercial streaming apps** (Netflix, Disney+, Prime Video, HBO Max, Spotify, official YouTube, …).
+        >   They're partner-signed and DRM-bound to the TV they shipped on: not redistributable, and a copied
+        >   `.wgt` wouldn't activate anyway. Most Samsung TVs already have them built in.
+        > - **Modded, cracked or "premium unlocked"** builds of paid apps or services.
+        > - **Closed-source packages** with no license that permits redistribution.
+        >
+        > 🏨 On a **hospitality / hotel TV** (`HG…` model), side-loading isn't possible at all — developer mode
+        > lives in the Smart Hub **Apps** screen, which that firmware doesn't expose.
+
   - type: input
     id: name
     attributes:
@@ -50,3 +64,11 @@ body:
       description: "Screenshots, device compatibility, or anything else useful."
     validations:
       required: false
+
+  - type: checkboxes
+    id: acknowledgement
+    attributes:
+      label: "✅ Before submitting"
+      options:
+        - label: "This isn't a commercial streaming app, a modded build, or otherwise not freely redistributable."
+          required: true

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Please check the [Releases](../../releases) page for version-specific details.
 We welcome **community contributions** and **app suggestions**!
 
 ### 💬 Request an App
-Open a new [Issue](../../issues/new?template=request-app.md) to suggest an app for future bundles.  
+Open a new [Issue](../../issues/new?template=request-app.yml) to suggest an app for future bundles.  
 Include:
 - App name
 - Description
@@ -119,6 +119,21 @@ Your app should be:
 > ⚠️ **Important:**  
 > We can only include applications that are **open-source** and **freely distributable**.  
 > Please make sure you have the legal right to redistribute any software you contribute.
+
+### 🚫 What We Can't Include
+
+- **Commercial streaming apps** — Netflix, Disney+, Prime Video, HBO Max, Spotify, official YouTube and friends.
+  These are partner-signed and their DRM is provisioned against the TV they shipped on, so a copied `.wgt`
+  can't legally be redistributed and wouldn't activate even if it installed. They're already built into most
+  Samsung TVs.
+- **Modded, cracked or "premium unlocked" builds** of paid apps or services.
+- **Closed-source packages** with no license that permits redistribution.
+
+Requests for these get closed as `wontfix`. It isn't gatekeeping — they simply can't work as side-loaded packages.
+
+> 🏨 **Hospitality / hotel TVs (`HG…` models):** side-loading needs developer mode, which is enabled from the
+> Smart Hub **Apps** screen — hospitality firmware doesn't expose it. Nothing in this repo can be installed on
+> those sets until the TV is taken out of hospitality mode.
 
 ---
 


### PR DESCRIPTION
Recurring requests for commercial streaming apps (Netflix #34, Spotify #13 and #17) all end the same way, so this makes the boundary visible before someone writes the issue.

**`.github/ISSUE_TEMPLATE/request-app.yml`**
- Notice at the top of the form: no commercial streaming apps, no modded/cracked builds, no closed-source packages without redistribution rights — with the *why* (partner-signed, DRM provisioned against the TV they shipped on).
- Note that hospitality/hotel (`HG…`) TVs can't side-load at all, since developer mode lives in the Smart Hub **Apps** screen that firmware doesn't expose.
- Required checkbox acknowledging the app isn't in one of those categories.

**`README.md`**
- New *What We Can't Include* subsection under Contributing, same content in longer form.
- Fixed the *Request an App* link: `request-app.md` → `request-app.yml` (the `.md` template doesn't exist, so that link opened a blank issue form).

Verified the form still parses as a valid issue form (8 body blocks, required fields unchanged), and the README table/badge renderer in `sync-packages.yml` only rewrites the table block and badge count, so the new prose won't be clobbered by the next sync.