### PR TITLE
Add OpenIPTV to the community catalog

### DIFF
--- a/packages/shayanline__OpenIPTV.json
+++ b/packages/shayanline__OpenIPTV.json
@@ -1,0 +1,13 @@
+{
+  "name": "OpenIPTV",
+  "description": "Privacy focused IPTV player for Samsung Tizen TVs with extended M3U playlists, favourites and search.",
+  "repo": "shayanline/OpenIPTV",
+  "source": "release",
+  "branch": "master",
+  "assets": [
+    {
+      "match": "OpenIPTV.wgt",
+      "output_name": "OpenIPTV.wgt"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add OpenIPTV to the Tizen community catalog.

## App details

- Repository: [shayanline/OpenIPTV](https://github.com/shayanline/OpenIPTV)
- OpenIPTV is an MIT licensed IPTV player for Samsung Tizen TVs.
- It supports extended M3U playlists, favourites, search, multiple playlists, and a multilingual interface.
- The manifest tracks the latest GitHub release and selects the attached `OpenIPTV.wgt` package.

## Validation

- [x] The package manifest follows the repository schema.
- [x] The latest release contains the matching widget.
- [x] The application is available under the MIT license.